### PR TITLE
fix: Erro na atualização versão 2.0.3 para 2.0.4

### DIFF
--- a/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-1.4.0-2.0.0.php
+++ b/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-1.4.0-2.0.0.php
@@ -38,21 +38,24 @@ $installer->startSetup();
 //$installer->addAttribute('quote_payment', 'traycheckout_typeful_line', array());
 // $installer->addAttribute('quote_payment', 'traycheckout_finger_print', array());
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+$quote_payment_table = $installer->getTable('sales_flat_quote_payment');
+$order_payment_table = $installer->getTable('sales_flat_order_payment');
+
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 

--- a/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-2.0.0-2.0.2.php
+++ b/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-2.0.0-2.0.2.php
@@ -38,21 +38,24 @@ $installer->startSetup();
 //$installer->addAttribute('quote_payment', 'traycheckout_typeful_line', array());
 // $installer->addAttribute('quote_payment', 'traycheckout_finger_print', array());
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+$quote_payment_table = $installer->getTable('sales_flat_quote_payment');
+$order_payment_table = $installer->getTable('sales_flat_order_payment');
+
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 

--- a/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-2.0.2-2.0.3.php
+++ b/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-2.0.2-2.0.3.php
@@ -38,21 +38,24 @@ $installer->startSetup();
 //$installer->addAttribute('quote_payment', 'traycheckout_typeful_line', array());
 // $installer->addAttribute('quote_payment', 'traycheckout_finger_print', array());
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+$quote_payment_table = $installer->getTable('sales_flat_quote_payment');
+$order_payment_table = $installer->getTable('sales_flat_order_payment');
+
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 

--- a/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-2.0.3-2.0.4.php
+++ b/Yapay_Intermediador-2.0.4/app/code/community/Tray/CheckoutApi/sql/checkoutapi_setup/mysql4-upgrade-2.0.3-2.0.4.php
@@ -38,21 +38,24 @@ $installer->startSetup();
 //$installer->addAttribute('quote_payment', 'traycheckout_typeful_line', array());
 // $installer->addAttribute('quote_payment', 'traycheckout_finger_print', array());
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+$quote_payment_table = $installer->getTable('sales_flat_quote_payment');
+$order_payment_table = $installer->getTable('sales_flat_order_payment');
+
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_finger_print')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_finger_print')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_finger_print` VARCHAR( 255 ) NULL DEFAULT NULL;");
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_quote_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_quote_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($quote_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$quote_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 
-if(!$installer->getConnection()->tableColumnExists('sales_flat_order_payment', 'traycheckout_payment_method_name')) {
-    $installer->run("ALTER TABLE  {$this->getTable('sales_flat_order_payment')} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
+if(!$installer->getConnection()->tableColumnExists($order_payment_table, 'traycheckout_payment_method_name')) {
+    $installer->run("ALTER TABLE  {$order_payment_table} ADD  `traycheckout_payment_method_name` VARCHAR( 255 ) NULL DEFAULT NULL;");
 
 }
 

--- a/Yapay_Intermediador-2.0.4/app/design/frontend/base/default/template/tray/checkoutapi/form/standard.phtml
+++ b/Yapay_Intermediador-2.0.4/app/design/frontend/base/default/template/tray/checkoutapi/form/standard.phtml
@@ -113,7 +113,7 @@
                 <li>                   
                     <div class="input-box">
                         <label for="<?php echo $_code ?>_cc_number"><?php echo Mage::helper('payment')->__('Credit Card Number') ?> <span class="required">*</span></label><br/>
-                        <input type="text" id="<?php echo $_code ?>_cc_number" name="payment[cc_number]" title="<?php echo Mage::helper('payment')->__('Credit Card Number') ?>" class="required-entry input-text validate-cc-number" value="<?php echo $this->getInfoData('cc_number')?>" onkeyup="identifyCreditCardTc(this.value.replace(/ /g,''))" onblur="getSplitValues('<?php echo number_format((float)$totals->grand_total, 2, '.',''); ?>',document.getElementById('tcPaymentMethod').value,'<?php echo Mage::getUrl('', array('_secure' => Mage::app()->getStore()->isCurrentlySecure())); ?>')"/>
+                        <input type="text" id="<?php echo $_code ?>_cc_number" name="payment[cc_number]" title="<?php echo Mage::helper('payment')->__('Credit Card Number') ?>" class="required-entry input-text validate-cc-number" value="<?php echo $this->getInfoData('cc_number')?>" onkeyup="identifyCreditCardTc(this.value.replace(/ /g,''))" onblur="getSplitValues('<?php echo number_format((float)$totals->grand_total, 2, '.',''); ?>',document.getElementById('tcPaymentMethod').value,'<?php echo Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, Mage::getStoreConfigFlag('web/secure/use_in_frontend')); ?>')"/>
                     </div>
                 </li>
                 <li>


### PR DESCRIPTION
Fixes #6

Recuperando o nome das tabelas com prefixo antes de operar a atualização.

Magento gerava um erro quando tentava executar o método `tableColumnExists`, pois o nome da tabela passado por parâmetro estava sem o prefixo, provocando erro em instalações do Magento que utilizam prefixo.